### PR TITLE
chore: update chart version and image repository

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v4.3.0
         with:
-          python-version: 3.7
+          python-version: 3.14
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1

--- a/charts/panope/Chart.yaml
+++ b/charts/panope/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.8.0"
+appVersion: "v0.9.1"

--- a/charts/panope/README.md
+++ b/charts/panope/README.md
@@ -41,7 +41,7 @@ $ helm install my-release 7knot/panope
 | agent.deployment.annotations | object | `{}` | Annotations to add to the deployment of agent |
 | agent.deployment.labels | object | `{}` | Labels to add to the deployment of agent |
 | agent.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the agent |
-| agent.image.repository | string | `"gcr.io/panope/agent"` | Image repository to use for the agent |
+| agent.image.repository | string | `"asia-docker.pkg.dev/panope/standard/agent"` | Image repository to use for the agent |
 | agent.image.tag | string | `nil` | Overrides the image tag whose default is the chart appVersion. |
 | agent.imagePullSecrets | list | `[]` | If defined, uses a Secret to pull an image from a private Docker registry or repository. |
 | agent.livenessProbe.failureThreshold | int | `5` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
@@ -107,7 +107,7 @@ $ helm install my-release 7knot/panope
 | observer.daemonset.annotations | object | `{}` | Annotations to add to the deployment |
 | observer.daemonset.labels | object | `{}` | Labels to add to the deployment |
 | observer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the observer |
-| observer.image.repository | string | `"gcr.io/panope/observer"` | Image repository to use for the observer |
+| observer.image.repository | string | `"asia-docker.pkg.dev/panope/standard/observer"` | Image repository to use for the observer |
 | observer.image.tag | string | `nil` | Overrides the image tag whose default is the chart appVersion |
 | observer.imagePullSecrets | list | `[]` | If defined, uses a Secret to pull an image from a private Docker registry or repository |
 | observer.livenessProbe.failureThreshold | int | `5` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |

--- a/charts/panope/templates/agent/poddisruptionbudget.yaml
+++ b/charts/panope/templates/agent/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.agent.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "panope.agent.fullname" . }}

--- a/charts/panope/values.yaml
+++ b/charts/panope/values.yaml
@@ -13,7 +13,7 @@ agent:
 
   image:
     # -- Image repository to use for the agent
-    repository: gcr.io/panope/agent
+    repository: asia-docker.pkg.dev/panope/standard/agent
     # -- Image pull policy for the agent
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.

--- a/charts/panope/values.yaml
+++ b/charts/panope/values.yaml
@@ -235,7 +235,7 @@ agent:
 observer:
   image:
     # -- Image repository to use for the observer
-    repository: gcr.io/panope/observer
+    repository: asia-docker.pkg.dev/panope/standard/observer
     # -- Image pull policy for the observer
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion


### PR DESCRIPTION
- Updated chart version to 0.9.0 and appVersion to v0.9.1
- Migrated agent image repository from GCR to Artifact Registry
- Updated PodDisruptionBudget API version from v1beta1 to stable v1